### PR TITLE
Introduce generics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "warc"
-version = "0.1.1"
+version = "0.2.0"
 description = "A Rust library for reading and writing WARC files."
 readme = "README.md"
 repository = "https://github.com/jedireza/warc"

--- a/examples/read_file.rs
+++ b/examples/read_file.rs
@@ -1,8 +1,8 @@
 use warc::header::{WARC_DATE, WARC_RECORD_ID};
-use warc::File;
+use warc::WarcReader;
 
 fn main() -> Result<(), std::io::Error> {
-    let file = File::open("warc_example.warc")?;
+    let file = WarcReader::from_path("warc_example.warc")?;
 
     let mut count = 0;
     for record in file {

--- a/examples/write_file.rs
+++ b/examples/write_file.rs
@@ -1,5 +1,5 @@
 use warc::header::{CONTENT_LENGTH, WARC_DATE, WARC_IP_ADDRESS, WARC_RECORD_ID, WARC_TYPE};
-use warc::{File, Record, RecordType};
+use warc::{Record, RecordType, WarcWriter};
 
 fn main() -> Result<(), std::io::Error> {
     let date = Record::make_date();
@@ -29,7 +29,7 @@ fn main() -> Result<(), std::io::Error> {
         body: body,
     };
 
-    let mut file = File::open("warc_example.warc")?;
+    let mut file = WarcWriter::from_path("warc_example.warc")?;
 
     let bytes_written = file.write(&record)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@
 mod error;
 pub use error::Error;
 
-mod file;
-pub use file::File;
+pub mod warc_types;
+pub use warc_types::{WarcReader, WarcWriter};
 
 pub mod header;
 


### PR DESCRIPTION
In order to handle warc data from other sources than files, I introduce
generics so that general Reader and Writer objects can be used.
I also split reading an writing