### PR TITLE
Add doc strings, split up warc_types.rs

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,12 +3,20 @@ use std::fmt;
 
 use crate::header::WarcHeader;
 
+/// An error type returned by WARC header parsing.
 #[derive(Debug, PartialEq)]
 pub enum Error {
+    /// An error occured identifing or parsing headers.
     ParseHeaders,
+    /// A header required by the standard is missing from the record. The record was well-formed,
+    /// but invalid.
     MissingHeader(WarcHeader),
+    /// The underlying read from the data source failed.
     ReadData,
+    /// More data was read than expected by the header metadata. The record was well-formed, but
+    /// invalid.
     ReadOverflow,
+    /// The end of the record's body was found unexpectedly.
     UnexpectedEOB,
 }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,3 +1,6 @@
+/// Represents a WARC header defined by the standard.
+///
+/// All headers are camel-case versions of the standard names, with the hyphens removed.
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub enum WarcHeader {
     ContentLength,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,10 @@
 mod error;
 pub use error::Error;
 
-pub mod warc_types;
-pub use warc_types::{WarcReader, WarcWriter};
+mod warc_reader;
+pub use warc_reader::WarcReader;
+mod warc_writer;
+pub use warc_writer::WarcWriter;
 
 pub mod header;
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -6,18 +6,24 @@ use uuid::Uuid;
 use crate::header::WarcHeader;
 use crate::Error as WarcError;
 
+/// A single WARC record parsed from a data stream.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Record {
+    /// The WARC standard version this record conforms to.
     pub version: String,
+    /// A set of all headers that are part of this record.
     pub headers: HashMap<crate::header::WarcHeader, Vec<u8>>,
+    /// The data body of this record.
     pub body: Vec<u8>,
 }
 
 impl Record {
+    /// Return a new UUID as a string value for the WARC-Record-ID header.
     pub fn make_uuid() -> String {
         format!("<{}>", Uuid::new_v4().to_urn())
     }
 
+    /// Return the current timestamp as a string value for the WARC-Date header.
     pub fn make_date() -> String {
         format!("{}", Utc::now())
     }

--- a/src/warc_reader.rs
+++ b/src/warc_reader.rs
@@ -12,17 +12,20 @@ use libflate::gzip::Decoder as GzipReader;
 const KB: usize = 1_024;
 const MB: usize = 1_048_576;
 
+/// A reader which iteratively parses WARC records from a stream.
 pub struct WarcReader<R> {
     reader: R,
 }
 
 impl<R: BufRead> WarcReader<R> {
+    /// Create a new reader.
     pub fn new(r: R) -> Self {
         WarcReader { reader: r }
     }
 }
 
 impl WarcReader<BufReader<fs::File>> {
+    /// Create a new reader which reads from file.
     pub fn from_path<P: AsRef<Path>>(path: P) -> io::Result<Self> {
         let file = fs::OpenOptions::new()
             .read(true)
@@ -37,6 +40,9 @@ impl WarcReader<BufReader<fs::File>> {
 
 #[cfg(feature = "gzip")]
 impl WarcReader<BufReader<GzipReader<std::fs::File>>> {
+    /// Create a new reader which reads from a compressed file.
+    ///
+    /// Only GZIP compression is currently supported.
     pub fn from_path_gzip<P: AsRef<Path>>(path: P) -> io::Result<Self> {
         let file = fs::OpenOptions::new()
             .read(true)

--- a/src/warc_reader.rs
+++ b/src/warc_reader.rs
@@ -3,83 +3,17 @@ use crate::{Error, Record};
 
 use std::fs;
 use std::io;
-use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 #[cfg(feature = "gzip")]
-use libflate::gzip::{Decoder as GzipReader, Encoder as GzipWriter};
+use libflate::gzip::Decoder as GzipReader;
 
 const KB: usize = 1_024;
 const MB: usize = 1_048_576;
 
 pub struct WarcReader<R> {
     reader: R,
-}
-
-pub struct WarcWriter<W> {
-    writer: W,
-}
-
-impl<W: Write> WarcWriter<W> {
-    pub fn new(w: W) -> Self {
-        WarcWriter { writer: w }
-    }
-
-    pub fn write(&mut self, record: &Record) -> io::Result<usize> {
-        let mut bytes_written = 0;
-
-        bytes_written += self.writer.write(&[87, 65, 82, 67, 47])?;
-        bytes_written += self.writer.write(record.version.as_bytes())?;
-        bytes_written += self.writer.write(&[13, 10])?;
-
-        for (token, value) in record.headers.iter() {
-            bytes_written += self.writer.write(token.to_string().as_bytes())?;
-            bytes_written += self.writer.write(&[58, 32])?;
-            bytes_written += self.writer.write(&value)?;
-            bytes_written += self.writer.write(&[13, 10])?;
-        }
-        bytes_written += self.writer.write(&[13, 10])?;
-
-        bytes_written += self.writer.write(&record.body)?;
-        bytes_written += self.writer.write(&[13, 10])?;
-        bytes_written += self.writer.write(&[13, 10])?;
-
-        Ok(bytes_written)
-    }
-}
-
-impl<W: Write> WarcWriter<BufWriter<W>> {
-    pub fn into_inner(self) -> Result<W, std::io::IntoInnerError<BufWriter<W>>> {
-        self.writer.into_inner()
-    }
-}
-
-impl WarcWriter<BufWriter<fs::File>> {
-    pub fn from_path<P: AsRef<Path>>(path: P) -> io::Result<Self> {
-        let file = fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(&path)?;
-        let writer = BufWriter::with_capacity(1 * MB, file);
-
-        Ok(WarcWriter::new(writer))
-    }
-}
-
-#[cfg(feature = "gzip")]
-impl WarcWriter<BufWriter<GzipWriter<std::fs::File>>> {
-    pub fn from_path_gzip<P: AsRef<Path>>(path: P) -> io::Result<Self> {
-        let file = fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(&path)?;
-        let gzip_stream = GzipWriter::new(file)?;
-        let writer = BufWriter::with_capacity(1 * MB, gzip_stream);
-
-        Ok(WarcWriter::new(writer))
-    }
 }
 
 impl<R: BufRead> WarcReader<R> {

--- a/src/warc_writer.rs
+++ b/src/warc_writer.rs
@@ -1,0 +1,77 @@
+use crate::Record;
+
+use std::fs;
+use std::io;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+#[cfg(feature = "gzip")]
+use libflate::gzip::Encoder as GzipWriter;
+
+const MB: usize = 1_048_576;
+
+pub struct WarcWriter<W> {
+    writer: W,
+}
+
+impl<W: Write> WarcWriter<W> {
+    pub fn new(w: W) -> Self {
+        WarcWriter { writer: w }
+    }
+
+    pub fn write(&mut self, record: &Record) -> io::Result<usize> {
+        let mut bytes_written = 0;
+
+        bytes_written += self.writer.write(&[87, 65, 82, 67, 47])?;
+        bytes_written += self.writer.write(record.version.as_bytes())?;
+        bytes_written += self.writer.write(&[13, 10])?;
+
+        for (token, value) in record.headers.iter() {
+            bytes_written += self.writer.write(token.to_string().as_bytes())?;
+            bytes_written += self.writer.write(&[58, 32])?;
+            bytes_written += self.writer.write(&value)?;
+            bytes_written += self.writer.write(&[13, 10])?;
+        }
+        bytes_written += self.writer.write(&[13, 10])?;
+
+        bytes_written += self.writer.write(&record.body)?;
+        bytes_written += self.writer.write(&[13, 10])?;
+        bytes_written += self.writer.write(&[13, 10])?;
+
+        Ok(bytes_written)
+    }
+}
+
+impl<W: Write> WarcWriter<BufWriter<W>> {
+    pub fn into_inner(self) -> Result<W, std::io::IntoInnerError<BufWriter<W>>> {
+        self.writer.into_inner()
+    }
+}
+
+impl WarcWriter<BufWriter<fs::File>> {
+    pub fn from_path<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)?;
+        let writer = BufWriter::with_capacity(1 * MB, file);
+
+        Ok(WarcWriter::new(writer))
+    }
+}
+
+#[cfg(feature = "gzip")]
+impl WarcWriter<BufWriter<GzipWriter<std::fs::File>>> {
+    pub fn from_path_gzip<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)?;
+        let gzip_stream = GzipWriter::new(file)?;
+        let writer = BufWriter::with_capacity(1 * MB, gzip_stream);
+
+        Ok(WarcWriter::new(writer))
+    }
+}


### PR DESCRIPTION
The main purpose of this PR is to add documentation. However, I wanted to take this opportunity to split up Reader and Writer into their own files, since I am adding so many lines to them anyway.

On my unpublished branch, the code I'm writing for reader behavior is getting complex enough I want to split that into its own file for readability. My intent is to take an incremental approach to my ideas, and doing the split in this PR makes sense as a first "increment" toward that.

That said, if you would prefer the docs by themselves, they are easy to extract.

Closes #6.