### PR TITLE
Add and require docstrings

### DIFF
--- a/examples/hello_warc.rs
+++ b/examples/hello_warc.rs
@@ -1,6 +1,6 @@
 use chrono::prelude::*;
 
-use warc::header::WarcHeader;
+use warc::WarcHeader;
 use warc::{BufferedBody, RawRecordHeader, Record, RecordType};
 
 fn main() {

--- a/examples/read_file.rs
+++ b/examples/read_file.rs
@@ -1,4 +1,4 @@
-use warc::header::WarcHeader;
+use warc::WarcHeader;
 use warc::WarcReader;
 
 fn main() -> Result<(), std::io::Error> {

--- a/examples/read_filtered.rs
+++ b/examples/read_filtered.rs
@@ -1,4 +1,4 @@
-use warc::header::WarcHeader;
+use warc::WarcHeader;
 use warc::WarcReader;
 
 macro_rules! usage_err {

--- a/examples/read_gzip.rs
+++ b/examples/read_gzip.rs
@@ -1,4 +1,4 @@
-use warc::header::WarcHeader;
+use warc::WarcHeader;
 use warc::WarcReader;
 
 fn main() -> Result<(), std::io::Error> {

--- a/examples/read_raw.rs
+++ b/examples/read_raw.rs
@@ -1,4 +1,4 @@
-use warc::header::WarcHeader;
+use warc::WarcHeader;
 use warc::WarcReader;
 
 fn main() -> Result<(), std::io::Error> {

--- a/examples/write_file.rs
+++ b/examples/write_file.rs
@@ -1,6 +1,6 @@
 use chrono::prelude::*;
 
-use warc::{header::WarcHeader, BufferedBody, Record, RecordType, WarcWriter};
+use warc::{BufferedBody, Record, RecordType, WarcHeader, WarcWriter};
 
 fn main() -> Result<(), std::io::Error> {
     let date = Utc::now();

--- a/examples/write_gzip.rs
+++ b/examples/write_gzip.rs
@@ -1,6 +1,6 @@
 use chrono::prelude::*;
 
-use warc::header::WarcHeader;
+use warc::WarcHeader;
 use warc::{BufferedBody, RawRecordHeader, Record, RecordType, WarcWriter};
 
 fn main() -> Result<(), std::io::Error> {

--- a/examples/write_raw.rs
+++ b/examples/write_raw.rs
@@ -1,6 +1,6 @@
 use chrono::prelude::*;
 
-use warc::header::WarcHeader;
+use warc::WarcHeader;
 use warc::{BufferedBody, RawRecordHeader, Record, RecordType, WarcWriter};
 
 fn main() -> Result<(), std::io::Error> {

--- a/src/header.rs
+++ b/src/header.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Represents a WARC header defined by the standard.
 ///
 /// All headers are camel-case versions of the standard names, with the hyphens removed.
+#[allow(missing_docs)]
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "with_serde", serde(into = "String"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,18 @@
+#![deny(missing_docs)]
 //! A WARC (Web ARChive) library
 
 mod error;
 pub use error::Error;
 
 mod warc_reader;
-pub use warc_reader::WarcReader;
+pub use warc_reader::*;
 mod warc_writer;
-pub use warc_writer::WarcWriter;
+pub use warc_writer::*;
 
-pub mod header;
+mod header;
+pub use header::WarcHeader;
 
+/// Core functions for parsing. Not recommended for direct use.
 pub mod parser;
 
 mod record;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -61,6 +61,7 @@ fn header(input: &[u8]) -> IResult<&[u8], (&[u8], &[u8])> {
     Ok((input, (token, value)))
 }
 
+/// Parse a WARC header block.
 // TODO: evaluate the use of `ErrorKind::Verify` here.
 pub fn headers(input: &[u8]) -> IResult<&[u8], (&str, Vec<(&str, &[u8])>, usize)> {
     let (input, version) = version(input)?;
@@ -107,6 +108,7 @@ pub fn headers(input: &[u8]) -> IResult<&[u8], (&str, Vec<(&str, &[u8])>, usize)
     Ok((input, (version, warc_headers, content_length.unwrap())))
 }
 
+/// Parse an entire WARC record.
 pub fn record(input: &[u8]) -> IResult<&[u8], (&str, Vec<(&str, &[u8])>, &[u8])> {
     let (input, (headers, _)) = tuple((headers, line_ending))(input)?;
     let (input, (body, _, _)) = tuple((take(headers.2), line_ending, line_ending))(input)?;

--- a/src/record_type.rs
+++ b/src/record_type.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #[derive(Clone, Debug, PartialEq)]
 pub enum RecordType {
     WarcInfo,

--- a/src/truncated_type.rs
+++ b/src/truncated_type.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #[derive(Clone, Debug, PartialEq)]
 pub enum TruncatedType {
     Length,

--- a/src/warc_reader.rs
+++ b/src/warc_reader.rs
@@ -81,6 +81,7 @@ impl WarcReader<BufReader<GzipReader<std::fs::File>>> {
     }
 }
 
+/// An iterator of raw records streamed from a reader. See `RawRecord` for more information.
 pub struct RawRecordIter<R> {
     reader: R,
 }
@@ -163,6 +164,7 @@ impl<R: BufRead> Iterator for RawRecordIter<R> {
     }
 }
 
+/// An iterator which returns the records read by a reader.
 pub struct RecordIter<R> {
     reader: R,
 }
@@ -251,6 +253,13 @@ impl<R: BufRead> Iterator for RecordIter<R> {
     }
 }
 
+/// An iterator-like type to "stream" records from a reader.
+///
+/// This API returns records which use the `StreamingBody` type. This allows reading record headers
+/// and metadata without reading the bodies. Bodies can be read or skipped as desired.
+///
+/// This is streaming iterator is particularly useful for streams of records which are indefinite
+/// or contain and records of unknown size.
 pub struct StreamingIter<'r, R> {
     reader: &'r mut R,
     current_item_size: u64,
@@ -297,6 +306,12 @@ impl<R: BufRead> StreamingIter<'_, R> {
         }
     }
 
+    /// Advance the stream to the next item.
+    ///
+    /// Returns one of the following:
+    /// * Some(Ok(r))` is the next record read from the stream.
+    /// * `Some(Err)` indicates there was a read error.
+    /// * `None` indicates no more records are returned.
     pub fn next_item(&mut self) -> Option<Result<Record<StreamingBody<'_, R>>, Error>> {
         if self.first_record {
             self.first_record = false;

--- a/src/warc_reader.rs
+++ b/src/warc_reader.rs
@@ -373,7 +373,7 @@ mod iter_raw_tests {
     use std::io::{BufReader, Cursor};
     use std::iter::FromIterator;
 
-    use crate::{header::WarcHeader, WarcReader};
+    use crate::{WarcHeader, WarcReader};
     macro_rules! create_reader {
         ($raw:expr) => {{
             BufReader::new(Cursor::new($raw.get(..).unwrap()))
@@ -489,7 +489,7 @@ mod next_item_tests {
     use std::io::{BufReader, Cursor};
     use std::iter::FromIterator;
 
-    use crate::{header::WarcHeader, WarcReader};
+    use crate::{WarcHeader, WarcReader};
 
     macro_rules! create_reader {
         ($raw:expr) => {{


### PR DESCRIPTION
It was pointed out in #27 a number of them were missing. This turned out to be trickier than I thought, because things were actually not exported.

Also adds `#![deny(missing_docs)]` to prevent this from happening in the future.