### PR TITLE
Switch to MultiDecoder when reading gzip files

### DIFF
--- a/src/warc_reader.rs
+++ b/src/warc_reader.rs
@@ -8,7 +8,7 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 #[cfg(feature = "gzip")]
-use libflate::gzip::Decoder as GzipReader;
+use libflate::gzip::MultiDecoder as GzipReader;
 
 const KB: usize = 1_024;
 const MB: usize = 1_048_576;


### PR DESCRIPTION
This let us read warc files from the Common Crawl data set directly. This is needed because
in these files each record is an independant gzip stream, and Encoder only reads the first one.