### PR TITLE
Remove file create/truncate options when reading warc from file path

### DIFF
--- a/src/warc_reader.rs
+++ b/src/warc_reader.rs
@@ -54,8 +54,6 @@ impl WarcReader<BufReader<fs::File>> {
     pub fn from_path<P: AsRef<Path>>(path: P) -> io::Result<Self> {
         let file = fs::OpenOptions::new()
             .read(true)
-            .create(true)
-            .truncate(false)
             .open(&path)?;
         let reader = BufReader::with_capacity(MB, file);
 

--- a/src/warc_reader.rs
+++ b/src/warc_reader.rs
@@ -52,9 +52,8 @@ impl<R: BufRead> WarcReader<R> {
 impl WarcReader<BufReader<fs::File>> {
     /// Create a new reader which reads from file.
     pub fn from_path<P: AsRef<Path>>(path: P) -> io::Result<Self> {
-        let file = fs::OpenOptions::new()
-            .read(true)
-            .open(&path)?;
+        let file = fs::File::open(&path)?;
+
         let reader = BufReader::with_capacity(MB, file);
 
         Ok(WarcReader::new(reader))
@@ -62,7 +61,7 @@ impl WarcReader<BufReader<fs::File>> {
 }
 
 #[cfg(feature = "gzip")]
-impl WarcReader<BufReader<GzipReader<BufReader<std::fs::File>>>> {
+impl WarcReader<BufReader<GzipReader<BufReader<fs::File>>>> {
     /// Create a new reader which reads from a compressed file.
     ///
     /// Only GZIP compression is currently supported.


### PR DESCRIPTION
This PR fixes #47.