### PR TITLE
deps: update libflate to version 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ url = "2"
 uuid = { version = "0.8.1", features = ["v4"] }
 
 [dependencies.libflate]
-version = "1"
+version = "2"
 optional = true
 
 [dependencies.serde]


### PR DESCRIPTION
From the [release notes](https://github.com/sile/libflate/releases/tag/2.0.0), the main thing is that libflate removed `no_std`, which doesn't affect this library.